### PR TITLE
Fix peek-then-consume race condition in undo token handling

### DIFF
--- a/src/Service/ProjectService.php
+++ b/src/Service/ProjectService.php
@@ -295,8 +295,9 @@ final class ProjectService
     /**
      * Undo any project operation using the token.
      *
-     * This method peeks at the token to determine the action type,
-     * then delegates to the appropriate undo method.
+     * Uses consume-then-validate pattern to avoid race conditions. The token
+     * is atomically consumed first, then validated. This ensures only one
+     * concurrent request can successfully use a token.
      *
      * @param User $user The user performing the undo
      * @param string $token The undo token
@@ -306,54 +307,48 @@ final class ProjectService
      */
     public function undo(User $user, string $token): array
     {
-        // First, peek at the token to determine the action type
-        $undoToken = $this->undoService->getUndoToken($user->getId() ?? '', $token);
+        // Atomically consume the token first to prevent race conditions
+        $undoToken = $this->undoService->consumeUndoToken($user->getId() ?? '', $token);
 
         if ($undoToken === null) {
             throw new \InvalidArgumentException('Invalid or expired undo token');
         }
 
-        // Verify this is a project token
+        // Validate entity type after consumption
+        // Note: Token is already consumed and cannot be reused
         if ($undoToken->entityType !== self::ENTITY_TYPE) {
             throw new \InvalidArgumentException('This undo token is not for a project');
         }
 
-        // Now consume the token and perform the undo based on action type
-        $consumedToken = $this->undoService->consumeUndoToken($user->getId() ?? '', $token);
-
-        if ($consumedToken === null) {
-            throw new \InvalidArgumentException('Failed to consume undo token');
-        }
-
         $warning = null;
 
-        switch ($consumedToken->action) {
+        switch ($undoToken->action) {
             case UndoAction::UPDATE->value:
-                $project = $this->performUndoUpdate($user, $consumedToken);
+                $project = $this->performUndoUpdate($user, $undoToken);
                 $message = 'Update operation undone successfully';
                 break;
 
             case UndoAction::ARCHIVE->value:
-                $project = $this->performUndoArchive($user, $consumedToken);
-                $wasArchived = $consumedToken->previousState['isArchived'] ?? false;
+                $project = $this->performUndoArchive($user, $undoToken);
+                $wasArchived = $undoToken->previousState['isArchived'] ?? false;
                 $message = $wasArchived
                     ? 'Project archived again (undo of unarchive)'
                     : 'Project unarchived (undo of archive)';
                 break;
 
             case UndoAction::DELETE->value:
-                $project = $this->performUndoDelete($user, $consumedToken);
+                $project = $this->performUndoDelete($user, $undoToken);
                 $message = 'Delete operation undone successfully. Note: Previously associated tasks were not restored.';
                 $warning = 'Tasks that were deleted with the project have been permanently lost';
                 break;
 
             default:
-                throw new \InvalidArgumentException('Unknown undo action type: ' . $consumedToken->action);
+                throw new \InvalidArgumentException('Unknown undo action type: ' . $undoToken->action);
         }
 
         return [
             'project' => $project,
-            'action' => $consumedToken->action,
+            'action' => $undoToken->action,
             'message' => $message,
             'warning' => $warning,
         ];

--- a/tests/Unit/Service/ProjectServiceTest.php
+++ b/tests/Unit/Service/ProjectServiceTest.php
@@ -615,11 +615,7 @@ class ProjectServiceTest extends UnitTestCase
             userId: 'user-123',
         );
 
-        $this->undoService->expects($this->once())
-            ->method('getUndoToken')
-            ->with('user-123', $undoToken->token)
-            ->willReturn($undoToken);
-
+        // Uses consume-then-validate pattern - no getUndoToken call
         $this->undoService->expects($this->once())
             ->method('consumeUndoToken')
             ->with('user-123', $undoToken->token)
@@ -654,11 +650,7 @@ class ProjectServiceTest extends UnitTestCase
             userId: 'user-123',
         );
 
-        $this->undoService->expects($this->once())
-            ->method('getUndoToken')
-            ->with('user-123', $undoToken->token)
-            ->willReturn($undoToken);
-
+        // Uses consume-then-validate pattern - no getUndoToken call
         $this->undoService->expects($this->once())
             ->method('consumeUndoToken')
             ->with('user-123', $undoToken->token)
@@ -693,11 +685,7 @@ class ProjectServiceTest extends UnitTestCase
             userId: 'user-123',
         );
 
-        $this->undoService->expects($this->once())
-            ->method('getUndoToken')
-            ->with('user-123', $undoToken->token)
-            ->willReturn($undoToken);
-
+        // Uses consume-then-validate pattern - no getUndoToken call
         $this->undoService->expects($this->once())
             ->method('consumeUndoToken')
             ->with('user-123', $undoToken->token)
@@ -718,8 +706,9 @@ class ProjectServiceTest extends UnitTestCase
     {
         $user = $this->createUserWithId();
 
+        // Uses consumeUndoToken directly instead of peek-then-consume
         $this->undoService->expects($this->once())
-            ->method('getUndoToken')
+            ->method('consumeUndoToken')
             ->with('user-123', 'invalid')
             ->willReturn(null);
 
@@ -739,8 +728,10 @@ class ProjectServiceTest extends UnitTestCase
             userId: 'user-123',
         );
 
+        // With consume-then-validate, the token is consumed first
+        // Note: Token is already consumed and cannot be reused after this
         $this->undoService->expects($this->once())
-            ->method('getUndoToken')
+            ->method('consumeUndoToken')
             ->with('user-123', $undoToken->token)
             ->willReturn($undoToken);
 


### PR DESCRIPTION
## Summary
Resolves a race condition in the undo token consumption flow where concurrent requests could both peek at a token and attempt to consume it, potentially leading to duplicate undo operations or inconsistent state.

## Changes Made

### Core Implementation
- **Added atomic Redis operations** (`RedisService`):
  - `getAndDelete()`: Uses Lua script to atomically GET and DEL a value in a single Redis operation
  - `getJsonAndDelete()`: Combines atomic get-and-delete with JSON decoding for one-time-use tokens

- **Updated token consumption** (`UndoService.consumeUndoToken()`):
  - Changed from separate `getJson()` + `delete()` calls to single atomic `getJsonAndDelete()` call
  - Ensures only one concurrent request can successfully consume a token
  - Added expiration validation after atomic retrieval
  - Improved error handling for deserialization failures

- **Refactored undo flow** (`ProjectService.undo()`):
  - Changed from peek-then-consume pattern to consume-then-validate pattern
  - Token is now atomically consumed first, then entity type is validated
  - Eliminates the race window between checking token validity and consuming it
  - Simplified logic by removing redundant token retrieval

### Testing
- Updated `UndoServiceTest`:
  - `testConsumeUndoTokenUsesAtomicGetAndDelete()`: Verifies atomic operation usage
  - `testConsumeUndoTokenIsOneTimeUse()`: Confirms token can only be consumed once
  - `testConsumeUndoTokenReturnsNullWhenExpired()`: Tests expiration handling
  - `testConsumeUndoTokenReturnsNullOnDeserializationError()`: Tests error handling

- Updated `ProjectServiceTest`:
  - Removed expectations for `getUndoToken()` calls
  - Updated to reflect consume-then-validate pattern
  - Added comments explaining the new flow

## Technical Details
The Lua script ensures atomicity at the Redis level, preventing the race condition where:
1. Request A peeks at token and sees it exists
2. Request B peeks at token and sees it exists
3. Request A consumes token (deletes it)
4. Request B tries to consume token (now fails or gets stale data)

With atomic get-and-delete, only one request can successfully retrieve the token value before it's deleted, making the operation safe under concurrent access.

## Documentation
Updated `PHASE-1-REVIEW-PLAN.md` to mark this issue as RESOLVED with detailed remediation notes.