### PR TITLE
Add API token expiration and refresh functionality

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -2,3 +2,7 @@
 ###> symfony/framework-bundle ###
 APP_SECRET=d472151c7cbe312ebf0c3eaf21191794
 ###< symfony/framework-bundle ###
+
+###> api configuration ###
+API_TOKEN_TTL_HOURS=48
+###< api configuration ###

--- a/.env.local.example
+++ b/.env.local.example
@@ -20,3 +20,8 @@ APP_SECRET=your_generated_secret_here
 # Allow additional origins in local development
 # CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 ###< nelmio/cors-bundle ###
+
+###> api configuration ###
+# API token lifetime in hours (default: 48)
+API_TOKEN_TTL_HOURS=48
+###< api configuration ###

--- a/.env.test
+++ b/.env.test
@@ -17,3 +17,7 @@ REDIS_URL="redis://redis:6379"
 ###> nelmio/cors-bundle ###
 CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 ###< nelmio/cors-bundle ###
+
+###> api configuration ###
+API_TOKEN_TTL_HOURS=48
+###< api configuration ###

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -5,6 +5,7 @@
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
     redis_url: '%env(REDIS_URL)%'
+    api_token_ttl_hours: '%env(int:API_TOKEN_TTL_HOURS)%'
 
 services:
     # default configuration for services in this file
@@ -45,3 +46,8 @@ services:
     App\Controller\Api\AuthController:
         arguments:
             $loginLimiter: '@limiter.login'
+
+    # User service with API token TTL configuration
+    App\Service\UserService:
+        arguments:
+            $apiTokenTtlHours: '%api_token_ttl_hours%'

--- a/docs/PHASE-1-REVIEW-PLAN.md
+++ b/docs/PHASE-1-REVIEW-PLAN.md
@@ -334,21 +334,37 @@ Add complexity requirements:
 
 ---
 
-### 2.6 API Token Has No Expiration
+### 2.6 API Token Has No Expiration ✅ FIXED
 
 **Category:** Data Safety
 **File:** `src/Entity/User.php`
+**Status:** RESOLVED (2026-01-24)
 
-#### Issue
+#### Issue (Original)
 - Tokens are valid indefinitely after creation
 - No `token_issued_at` or `token_expires_at` fields
 - Compromised tokens remain valid forever
 
-#### Remediation
-1. Add columns: `api_token_issued_at`, `api_token_expires_at`
-2. Default expiration: 24-72 hours
-3. Validate expiration in `ApiTokenAuthenticator`
-4. Add token refresh endpoint
+#### Resolution Implemented
+1. ✅ Added `api_token_issued_at` and `api_token_expires_at` columns to User entity
+2. ✅ Default expiration: 48 hours (configurable via `API_TOKEN_TTL_HOURS` env var)
+3. ✅ Expiration validation in `ApiTokenAuthenticator` with clear error messages
+4. ✅ Added `POST /api/v1/auth/refresh` endpoint for token refresh
+5. ✅ Refresh window: 7 days after expiration (requires re-login after)
+6. ✅ Migration: `Version20260124000001.php` - existing tokens set to expire in 48 hours
+7. ✅ Unit and functional tests added for token expiration and refresh
+
+#### Files Changed
+- `src/Entity/User.php` - Added expiration fields and `isApiTokenExpired()` method
+- `src/Service/UserService.php` - Token generation with expiration, expiration checking
+- `src/Controller/Api/AuthController.php` - Added refresh endpoint, expiresAt in responses
+- `src/Security/ApiTokenAuthenticator.php` - Expired token detection with specific error
+- `migrations/Version20260124000001.php` - Database schema migration
+- `config/services.yaml` - Token TTL configuration
+- `.env.dev`, `.env.test`, `.env.local.example` - `API_TOKEN_TTL_HOURS` variable
+- `tests/Unit/Entity/UserTest.php` - Token expiration unit tests
+- `tests/Unit/Service/UserServiceTest.php` - Service layer unit tests
+- `tests/Functional/Api/AuthApiTest.php` - Functional tests for expiration and refresh
 
 ---
 
@@ -706,7 +722,7 @@ class UndoOperationDispatcher {
 1. Implement user deletion endpoint
 2. Implement data export endpoint
 3. Implement password reset flow
-4. Add token expiration
+4. ~~Add token expiration~~ ✅ COMPLETED (2026-01-24)
 
 ### Week 3: Code Quality
 1. Fix N+1 query in task reordering

--- a/migrations/Version20260124000001.php
+++ b/migrations/Version20260124000001.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Migration: Add API token expiration fields to users table
+ */
+final class Version20260124000001 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add api_token_issued_at and api_token_expires_at columns to users table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE users ADD api_token_issued_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
+        $this->addSql('ALTER TABLE users ADD api_token_expires_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
+        $this->addSql('CREATE INDEX idx_users_api_token_expires_at ON users (api_token_expires_at)');
+        $this->addSql('COMMENT ON COLUMN users.api_token_issued_at IS \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('COMMENT ON COLUMN users.api_token_expires_at IS \'(DC2Type:datetime_immutable)\'');
+
+        // Set expiration for existing tokens (48 hours from now)
+        $this->addSql('UPDATE users SET api_token_issued_at = NOW(), api_token_expires_at = NOW() + INTERVAL \'48 hours\' WHERE api_token IS NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS idx_users_api_token_expires_at');
+        $this->addSql('ALTER TABLE users DROP COLUMN IF EXISTS api_token_issued_at');
+        $this->addSql('ALTER TABLE users DROP COLUMN IF EXISTS api_token_expires_at');
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -41,6 +41,12 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\Column(type: Types::STRING, length: 255, unique: true, nullable: true, name: 'api_token')]
     private ?string $apiToken = null;
 
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true, name: 'api_token_issued_at')]
+    private ?\DateTimeImmutable $apiTokenIssuedAt = null;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true, name: 'api_token_expires_at')]
+    private ?\DateTimeImmutable $apiTokenExpiresAt = null;
+
     #[ORM\Column(type: Types::DATETIME_IMMUTABLE, name: 'created_at')]
     private \DateTimeImmutable $createdAt;
 
@@ -140,7 +146,49 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     {
         $this->apiToken = $apiToken;
 
+        // Clear expiration when token is revoked
+        if ($apiToken === null) {
+            $this->apiTokenIssuedAt = null;
+            $this->apiTokenExpiresAt = null;
+        }
+
         return $this;
+    }
+
+    public function getApiTokenIssuedAt(): ?\DateTimeImmutable
+    {
+        return $this->apiTokenIssuedAt;
+    }
+
+    public function setApiTokenIssuedAt(?\DateTimeImmutable $apiTokenIssuedAt): static
+    {
+        $this->apiTokenIssuedAt = $apiTokenIssuedAt;
+
+        return $this;
+    }
+
+    public function getApiTokenExpiresAt(): ?\DateTimeImmutable
+    {
+        return $this->apiTokenExpiresAt;
+    }
+
+    public function setApiTokenExpiresAt(?\DateTimeImmutable $apiTokenExpiresAt): static
+    {
+        $this->apiTokenExpiresAt = $apiTokenExpiresAt;
+
+        return $this;
+    }
+
+    /**
+     * Checks if the API token has expired.
+     */
+    public function isApiTokenExpired(): bool
+    {
+        if ($this->apiTokenExpiresAt === null) {
+            return true; // No expiration set means expired
+        }
+
+        return $this->apiTokenExpiresAt < new \DateTimeImmutable();
     }
 
     public function getCreatedAt(): \DateTimeImmutable

--- a/tests/Functional/ApiTestCase.php
+++ b/tests/Functional/ApiTestCase.php
@@ -106,6 +106,8 @@ abstract class ApiTestCase extends WebTestCase
             /** @var TokenGenerator $tokenGenerator */
             $tokenGenerator = static::getContainer()->get(TokenGenerator::class);
             $user->setApiToken($tokenGenerator->generateApiToken());
+            $user->setApiTokenIssuedAt(new \DateTimeImmutable());
+            $user->setApiTokenExpiresAt(new \DateTimeImmutable('+48 hours'));
         }
 
         $this->entityManager->persist($user);

--- a/tests/Unit/Entity/UserTest.php
+++ b/tests/Unit/Entity/UserTest.php
@@ -87,6 +87,89 @@ class UserTest extends UnitTestCase
     }
 
     // ========================================
+    // API Token Expiration Tests
+    // ========================================
+
+    public function testIsApiTokenExpiredReturnsTrueWhenNoExpiration(): void
+    {
+        $user = new User();
+        $user->setApiToken('token');
+        // No expiration set
+
+        $this->assertTrue($user->isApiTokenExpired());
+    }
+
+    public function testIsApiTokenExpiredReturnsTrueWhenExpired(): void
+    {
+        $user = new User();
+        $user->setApiToken('token');
+        $user->setApiTokenExpiresAt(new \DateTimeImmutable('-1 hour'));
+
+        $this->assertTrue($user->isApiTokenExpired());
+    }
+
+    public function testIsApiTokenExpiredReturnsFalseWhenNotExpired(): void
+    {
+        $user = new User();
+        $user->setApiToken('token');
+        $user->setApiTokenExpiresAt(new \DateTimeImmutable('+1 hour'));
+
+        $this->assertFalse($user->isApiTokenExpired());
+    }
+
+    public function testSetApiTokenNullClearsExpiration(): void
+    {
+        $user = new User();
+        $user->setApiToken('token');
+        $user->setApiTokenIssuedAt(new \DateTimeImmutable());
+        $user->setApiTokenExpiresAt(new \DateTimeImmutable('+1 hour'));
+
+        $user->setApiToken(null);
+
+        $this->assertNull($user->getApiToken());
+        $this->assertNull($user->getApiTokenIssuedAt());
+        $this->assertNull($user->getApiTokenExpiresAt());
+    }
+
+    public function testGetApiTokenIssuedAtReturnsSetValue(): void
+    {
+        $user = new User();
+        $date = new \DateTimeImmutable('2024-01-15 10:00:00');
+
+        $user->setApiTokenIssuedAt($date);
+
+        $this->assertSame($date, $user->getApiTokenIssuedAt());
+    }
+
+    public function testGetApiTokenExpiresAtReturnsSetValue(): void
+    {
+        $user = new User();
+        $date = new \DateTimeImmutable('2024-01-17 10:00:00');
+
+        $user->setApiTokenExpiresAt($date);
+
+        $this->assertSame($date, $user->getApiTokenExpiresAt());
+    }
+
+    public function testSetApiTokenIssuedAtReturnsSelf(): void
+    {
+        $user = new User();
+
+        $result = $user->setApiTokenIssuedAt(new \DateTimeImmutable());
+
+        $this->assertSame($user, $result);
+    }
+
+    public function testSetApiTokenExpiresAtReturnsSelf(): void
+    {
+        $user = new User();
+
+        $result = $user->setApiTokenExpiresAt(new \DateTimeImmutable());
+
+        $this->assertSame($user, $result);
+    }
+
+    // ========================================
     // Roles Tests
     // ========================================
 


### PR DESCRIPTION
## Summary
Implements API token expiration to address the security vulnerability where tokens were valid indefinitely. Tokens now expire after a configurable period (default 48 hours) and can be refreshed within a 7-day window after expiration.

## Changes Made

### Core Implementation
- **User Entity**: Added `api_token_issued_at` and `api_token_expires_at` timestamp fields with `isApiTokenExpired()` method
- **UserService**: 
  - Token generation now sets expiration based on `API_TOKEN_TTL_HOURS` config (default 48 hours)
  - Added `findByApiTokenIgnoreExpiration()` for token refresh flow
  - Added `getTokenExpiresAt()` helper method
- **ApiTokenAuthenticator**: Enhanced to validate token expiration and provide clear error messages
- **AuthController**: 
  - Added `POST /api/v1/auth/refresh` endpoint for token refresh
  - Returns `expiresAt` in token responses (login, register, refresh)
  - Refresh endpoint allows expired tokens within 7-day window

### Configuration & Database
- Added `API_TOKEN_TTL_HOURS` environment variable (configurable, default 48 hours)
- Database migration creates new columns and indexes, sets expiration for existing tokens
- Updated `.env.dev`, `.env.test`, and `.env.local.example` with new config

### Testing
- **Unit Tests**: Token expiration logic, service layer token generation and validation
- **Functional Tests**: Login/register expiration responses, expired token rejection, refresh endpoint (success, expired tokens, invalid tokens, outside refresh window)
- **Test Utilities**: Updated `ApiTestCase` to set token expiration on test users

## Implementation Details
- Tokens expire after configured hours (default 48)
- Expired tokens can be refreshed for 7 days after expiration
- After 7-day window, user must re-login
- Token revocation clears both issued and expiration timestamps
- Clear error messages distinguish between invalid and expired tokens
- Refresh endpoint accepts both `Authorization: Bearer` and `X-API-Key` headers