### PR TITLE
Refactor ApiExceptionListener using Strategy pattern with exception mappers

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -33,7 +33,13 @@ services:
         arguments:
             $apiLogger: '@monolog.logger.api'
 
-    App\EventListener\ApiExceptionListener:
+    # Exception mapper registry with tagged mappers
+    App\EventListener\ExceptionMapper\ExceptionMapperRegistry:
+        arguments:
+            $mappers: !tagged_iterator { tag: 'app.exception_mapper', default_priority_method: 'getPriority' }
+
+    # Server error mapper needs environment for debug info
+    App\EventListener\ExceptionMapper\Fallback\ServerErrorMapper:
         arguments:
             $environment: '%kernel.environment%'
 

--- a/src/EventListener/ApiExceptionListener.php
+++ b/src/EventListener/ApiExceptionListener.php
@@ -4,44 +4,19 @@ declare(strict_types=1);
 
 namespace App\EventListener;
 
-use App\Exception\EntityNotFoundException;
-use App\Exception\ForbiddenException;
-use App\Exception\InvalidPriorityException;
-use App\Exception\InvalidRecurrenceException;
-use App\Exception\InvalidStatusException;
-use App\Exception\UnauthorizedException;
-use App\Exception\ValidationException;
+use App\EventListener\ExceptionMapper\ExceptionMapperRegistry;
 use App\Service\ApiLogger;
 use App\Service\ResponseFormatter;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException as SymfonyUnauthorizedHttpException;
-use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Validator\Exception\ValidationFailedException;
 
 /**
  * Listener that catches all exceptions for API routes and returns consistent error responses.
  *
- * Maps exceptions to appropriate HTTP status codes and error codes:
- * - VALIDATION_ERROR (400/422)
- * - NOT_FOUND (404)
- * - UNAUTHORIZED (401)
- * - FORBIDDEN (403)
- * - RATE_LIMITED (429)
- * - INVALID_STATUS (400)
- * - INVALID_PRIORITY (400)
- * - CONFLICT (409)
- * - SERVER_ERROR (500)
+ * Delegates exception mapping to specialized ExceptionMapperInterface implementations
+ * via the ExceptionMapperRegistry.
  */
 #[AsEventListener(event: KernelEvents::EXCEPTION, method: 'onKernelException', priority: 100)]
 final class ApiExceptionListener
@@ -49,7 +24,7 @@ final class ApiExceptionListener
     public function __construct(
         private readonly ResponseFormatter $responseFormatter,
         private readonly ApiLogger $apiLogger,
-        private readonly string $environment,
+        private readonly ExceptionMapperRegistry $mapperRegistry,
     ) {
     }
 
@@ -71,15 +46,15 @@ final class ApiExceptionListener
             'method' => $request->getMethod(),
         ]);
 
-        // Map exception to response
-        [$errorCode, $message, $statusCode, $details] = $this->mapException($exception);
+        // Map exception to response using the registry
+        $mapping = $this->mapperRegistry->map($exception);
 
         // Create error response
         $response = $this->responseFormatter->error(
-            $message,
-            $errorCode,
-            $statusCode,
-            $details
+            $mapping->message,
+            $mapping->errorCode,
+            $mapping->statusCode,
+            $mapping->details,
         );
 
         // Add any additional headers from HTTP exceptions
@@ -90,237 +65,5 @@ final class ApiExceptionListener
         }
 
         $event->setResponse($response);
-    }
-
-    /**
-     * Maps an exception to error code, message, status code, and details.
-     *
-     * @param \Throwable $exception
-     * @return array{0: string, 1: string, 2: int, 3: array<string, mixed>}
-     */
-    private function mapException(\Throwable $exception): array
-    {
-        // Handle Symfony validation exceptions
-        if ($exception instanceof ValidationFailedException) {
-            return $this->handleValidationException($exception);
-        }
-
-        // Handle custom domain exceptions with errorCode property
-        if ($exception instanceof InvalidStatusException) {
-            return [
-                $exception->errorCode,
-                $exception->getMessage(),
-                $exception->getStatusCode(),
-                [
-                    'invalidStatus' => $exception->invalidStatus,
-                    'validStatuses' => $exception->validStatuses,
-                ],
-            ];
-        }
-
-        if ($exception instanceof InvalidPriorityException) {
-            return [
-                $exception->errorCode,
-                $exception->getMessage(),
-                $exception->getStatusCode(),
-                [
-                    'invalidPriority' => $exception->invalidPriority,
-                    'minPriority' => $exception->minPriority,
-                    'maxPriority' => $exception->maxPriority,
-                ],
-            ];
-        }
-
-        if ($exception instanceof InvalidRecurrenceException) {
-            $details = ['reason' => $exception->reason];
-            if ($exception->invalidValue !== null) {
-                $details['invalidValue'] = $exception->invalidValue;
-            }
-            if ($exception->validValues !== null) {
-                $details['validValues'] = $exception->validValues;
-            }
-            return [
-                $exception->errorCode,
-                $exception->getMessage(),
-                $exception->getStatusCode(),
-                $details,
-            ];
-        }
-
-        if ($exception instanceof ValidationException) {
-            return [
-                $exception->errorCode,
-                $exception->getMessage(),
-                $exception->getStatusCode(),
-                ['errors' => $exception->getErrors()],
-            ];
-        }
-
-        if ($exception instanceof EntityNotFoundException) {
-            return [
-                $exception->errorCode,
-                $exception->getMessage(),
-                $exception->getStatusCode(),
-                [
-                    'entityType' => $exception->entityType,
-                    'entityId' => $exception->entityId,
-                ],
-            ];
-        }
-
-        if ($exception instanceof UnauthorizedException) {
-            return [
-                $exception->errorCode,
-                $exception->getMessage(),
-                $exception->getStatusCode(),
-                [],
-            ];
-        }
-
-        if ($exception instanceof ForbiddenException) {
-            return [
-                $exception->errorCode,
-                $exception->getMessage(),
-                $exception->getStatusCode(),
-                ['reason' => $exception->reason],
-            ];
-        }
-
-        // Handle Symfony Security exceptions (for unauthenticated/unauthorized requests)
-        if ($exception instanceof AuthenticationException) {
-            return [
-                'UNAUTHORIZED',
-                'Authentication required',
-                Response::HTTP_UNAUTHORIZED,
-                [],
-            ];
-        }
-
-        if ($exception instanceof AccessDeniedException) {
-            return [
-                'UNAUTHORIZED',
-                'Authentication required',
-                Response::HTTP_UNAUTHORIZED,
-                [],
-            ];
-        }
-
-        // Handle HTTP exceptions
-        if ($exception instanceof HttpExceptionInterface) {
-            return $this->handleHttpException($exception);
-        }
-
-        // Handle all other exceptions as server errors
-        return $this->handleServerError($exception);
-    }
-
-    /**
-     * Handles validation exceptions.
-     *
-     * @return array{0: string, 1: string, 2: int, 3: array<string, mixed>}
-     */
-    private function handleValidationException(ValidationFailedException $exception): array
-    {
-        $violations = $exception->getViolations();
-        $errors = [];
-
-        foreach ($violations as $violation) {
-            $propertyPath = $violation->getPropertyPath();
-            $errors[$propertyPath][] = $violation->getMessage();
-        }
-
-        return [
-            'VALIDATION_ERROR',
-            'Validation failed',
-            Response::HTTP_UNPROCESSABLE_ENTITY,
-            ['errors' => $errors],
-        ];
-    }
-
-    /**
-     * Handles HTTP exceptions.
-     *
-     * @return array{0: string, 1: string, 2: int, 3: array<string, mixed>}
-     */
-    private function handleHttpException(HttpExceptionInterface $exception): array
-    {
-        $statusCode = $exception->getStatusCode();
-        $message = $exception->getMessage();
-
-        // Use default message if empty
-        if (empty($message)) {
-            $message = Response::$statusTexts[$statusCode] ?? 'An error occurred';
-        }
-
-        $errorCode = match (true) {
-            $exception instanceof NotFoundHttpException => 'NOT_FOUND',
-            $exception instanceof SymfonyUnauthorizedHttpException => 'UNAUTHORIZED',
-            $exception instanceof AccessDeniedHttpException => 'FORBIDDEN',
-            $exception instanceof TooManyRequestsHttpException => 'RATE_LIMIT_EXCEEDED',
-            $exception instanceof BadRequestHttpException => 'BAD_REQUEST',
-            $exception instanceof UnprocessableEntityHttpException => 'VALIDATION_ERROR',
-            $exception instanceof ConflictHttpException => 'CONFLICT',
-            default => $this->getErrorCodeFromStatusCode($statusCode),
-        };
-
-        return [
-            $errorCode,
-            $message,
-            $statusCode,
-            [],
-        ];
-    }
-
-    /**
-     * Handles server errors (500-level exceptions).
-     *
-     * @return array{0: string, 1: string, 2: int, 3: array<string, mixed>}
-     */
-    private function handleServerError(\Throwable $exception): array
-    {
-        // In development, show the actual error message
-        // In production, show a generic message
-        $message = $this->environment === 'dev'
-            ? $exception->getMessage()
-            : 'An internal server error occurred';
-
-        $details = [];
-
-        // In development, include additional debug information
-        if ($this->environment === 'dev') {
-            $details = [
-                'exception' => get_class($exception),
-                'file' => $exception->getFile(),
-                'line' => $exception->getLine(),
-            ];
-        }
-
-        return [
-            'SERVER_ERROR',
-            $message,
-            Response::HTTP_INTERNAL_SERVER_ERROR,
-            $details,
-        ];
-    }
-
-    /**
-     * Gets an error code based on HTTP status code.
-     */
-    private function getErrorCodeFromStatusCode(int $statusCode): string
-    {
-        return match ($statusCode) {
-            400 => 'BAD_REQUEST',
-            401 => 'UNAUTHORIZED',
-            403 => 'FORBIDDEN',
-            404 => 'NOT_FOUND',
-            405 => 'METHOD_NOT_ALLOWED',
-            409 => 'CONFLICT',
-            422 => 'VALIDATION_ERROR',
-            429 => 'RATE_LIMIT_EXCEEDED',
-            500 => 'SERVER_ERROR',
-            501 => 'NOT_IMPLEMENTED',
-            503 => 'SERVICE_UNAVAILABLE',
-            default => 'ERROR',
-        };
     }
 }

--- a/src/EventListener/ExceptionMapper/Domain/EntityNotFoundExceptionMapper.php
+++ b/src/EventListener/ExceptionMapper/Domain/EntityNotFoundExceptionMapper.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener\ExceptionMapper\Domain;
+
+use App\EventListener\ExceptionMapper\ExceptionMapperInterface;
+use App\EventListener\ExceptionMapper\ExceptionMapping;
+use App\Exception\EntityNotFoundException;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Maps EntityNotFoundException to error response.
+ */
+#[AutoconfigureTag('app.exception_mapper')]
+final class EntityNotFoundExceptionMapper implements ExceptionMapperInterface
+{
+    public static function getPriority(): int
+    {
+        return 100;
+    }
+
+    public function canHandle(\Throwable $exception): bool
+    {
+        return $exception instanceof EntityNotFoundException;
+    }
+
+    public function map(\Throwable $exception): ExceptionMapping
+    {
+        assert($exception instanceof EntityNotFoundException);
+
+        return new ExceptionMapping(
+            $exception->errorCode,
+            $exception->getMessage(),
+            $exception->getStatusCode(),
+            [
+                'entityType' => $exception->entityType,
+                'entityId' => $exception->entityId,
+            ],
+        );
+    }
+}

--- a/src/EventListener/ExceptionMapper/Domain/ForbiddenExceptionMapper.php
+++ b/src/EventListener/ExceptionMapper/Domain/ForbiddenExceptionMapper.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener\ExceptionMapper\Domain;
+
+use App\EventListener\ExceptionMapper\ExceptionMapperInterface;
+use App\EventListener\ExceptionMapper\ExceptionMapping;
+use App\Exception\ForbiddenException;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Maps ForbiddenException to error response.
+ */
+#[AutoconfigureTag('app.exception_mapper')]
+final class ForbiddenExceptionMapper implements ExceptionMapperInterface
+{
+    public static function getPriority(): int
+    {
+        return 100;
+    }
+
+    public function canHandle(\Throwable $exception): bool
+    {
+        return $exception instanceof ForbiddenException;
+    }
+
+    public function map(\Throwable $exception): ExceptionMapping
+    {
+        assert($exception instanceof ForbiddenException);
+
+        return new ExceptionMapping(
+            $exception->errorCode,
+            $exception->getMessage(),
+            $exception->getStatusCode(),
+            ['reason' => $exception->reason],
+        );
+    }
+}

--- a/src/EventListener/ExceptionMapper/Domain/InvalidPriorityExceptionMapper.php
+++ b/src/EventListener/ExceptionMapper/Domain/InvalidPriorityExceptionMapper.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener\ExceptionMapper\Domain;
+
+use App\EventListener\ExceptionMapper\ExceptionMapperInterface;
+use App\EventListener\ExceptionMapper\ExceptionMapping;
+use App\Exception\InvalidPriorityException;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Maps InvalidPriorityException to error response.
+ */
+#[AutoconfigureTag('app.exception_mapper')]
+final class InvalidPriorityExceptionMapper implements ExceptionMapperInterface
+{
+    public static function getPriority(): int
+    {
+        return 100;
+    }
+
+    public function canHandle(\Throwable $exception): bool
+    {
+        return $exception instanceof InvalidPriorityException;
+    }
+
+    public function map(\Throwable $exception): ExceptionMapping
+    {
+        assert($exception instanceof InvalidPriorityException);
+
+        return new ExceptionMapping(
+            $exception->errorCode,
+            $exception->getMessage(),
+            $exception->getStatusCode(),
+            [
+                'invalidPriority' => $exception->invalidPriority,
+                'minPriority' => $exception->minPriority,
+                'maxPriority' => $exception->maxPriority,
+            ],
+        );
+    }
+}

--- a/src/EventListener/ExceptionMapper/Domain/InvalidRecurrenceExceptionMapper.php
+++ b/src/EventListener/ExceptionMapper/Domain/InvalidRecurrenceExceptionMapper.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener\ExceptionMapper\Domain;
+
+use App\EventListener\ExceptionMapper\ExceptionMapperInterface;
+use App\EventListener\ExceptionMapper\ExceptionMapping;
+use App\Exception\InvalidRecurrenceException;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Maps InvalidRecurrenceException to error response.
+ */
+#[AutoconfigureTag('app.exception_mapper')]
+final class InvalidRecurrenceExceptionMapper implements ExceptionMapperInterface
+{
+    public static function getPriority(): int
+    {
+        return 100;
+    }
+
+    public function canHandle(\Throwable $exception): bool
+    {
+        return $exception instanceof InvalidRecurrenceException;
+    }
+
+    public function map(\Throwable $exception): ExceptionMapping
+    {
+        assert($exception instanceof InvalidRecurrenceException);
+
+        $details = ['reason' => $exception->reason];
+
+        if ($exception->invalidValue !== null) {
+            $details['invalidValue'] = $exception->invalidValue;
+        }
+
+        if ($exception->validValues !== null) {
+            $details['validValues'] = $exception->validValues;
+        }
+
+        return new ExceptionMapping(
+            $exception->errorCode,
+            $exception->getMessage(),
+            $exception->getStatusCode(),
+            $details,
+        );
+    }
+}

--- a/src/EventListener/ExceptionMapper/Domain/InvalidStatusExceptionMapper.php
+++ b/src/EventListener/ExceptionMapper/Domain/InvalidStatusExceptionMapper.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener\ExceptionMapper\Domain;
+
+use App\EventListener\ExceptionMapper\ExceptionMapperInterface;
+use App\EventListener\ExceptionMapper\ExceptionMapping;
+use App\Exception\InvalidStatusException;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Maps InvalidStatusException to error response.
+ */
+#[AutoconfigureTag('app.exception_mapper')]
+final class InvalidStatusExceptionMapper implements ExceptionMapperInterface
+{
+    public static function getPriority(): int
+    {
+        return 100;
+    }
+
+    public function canHandle(\Throwable $exception): bool
+    {
+        return $exception instanceof InvalidStatusException;
+    }
+
+    public function map(\Throwable $exception): ExceptionMapping
+    {
+        assert($exception instanceof InvalidStatusException);
+
+        return new ExceptionMapping(
+            $exception->errorCode,
+            $exception->getMessage(),
+            $exception->getStatusCode(),
+            [
+                'invalidStatus' => $exception->invalidStatus,
+                'validStatuses' => $exception->validStatuses,
+            ],
+        );
+    }
+}

--- a/src/EventListener/ExceptionMapper/Domain/UnauthorizedExceptionMapper.php
+++ b/src/EventListener/ExceptionMapper/Domain/UnauthorizedExceptionMapper.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener\ExceptionMapper\Domain;
+
+use App\EventListener\ExceptionMapper\ExceptionMapperInterface;
+use App\EventListener\ExceptionMapper\ExceptionMapping;
+use App\Exception\UnauthorizedException;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Maps UnauthorizedException to error response.
+ */
+#[AutoconfigureTag('app.exception_mapper')]
+final class UnauthorizedExceptionMapper implements ExceptionMapperInterface
+{
+    public static function getPriority(): int
+    {
+        return 100;
+    }
+
+    public function canHandle(\Throwable $exception): bool
+    {
+        return $exception instanceof UnauthorizedException;
+    }
+
+    public function map(\Throwable $exception): ExceptionMapping
+    {
+        assert($exception instanceof UnauthorizedException);
+
+        return new ExceptionMapping(
+            $exception->errorCode,
+            $exception->getMessage(),
+            $exception->getStatusCode(),
+        );
+    }
+}

--- a/src/EventListener/ExceptionMapper/Domain/ValidationExceptionMapper.php
+++ b/src/EventListener/ExceptionMapper/Domain/ValidationExceptionMapper.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener\ExceptionMapper\Domain;
+
+use App\EventListener\ExceptionMapper\ExceptionMapperInterface;
+use App\EventListener\ExceptionMapper\ExceptionMapping;
+use App\Exception\ValidationException;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Maps ValidationException to error response.
+ */
+#[AutoconfigureTag('app.exception_mapper')]
+final class ValidationExceptionMapper implements ExceptionMapperInterface
+{
+    public static function getPriority(): int
+    {
+        return 100;
+    }
+
+    public function canHandle(\Throwable $exception): bool
+    {
+        return $exception instanceof ValidationException;
+    }
+
+    public function map(\Throwable $exception): ExceptionMapping
+    {
+        assert($exception instanceof ValidationException);
+
+        return new ExceptionMapping(
+            $exception->errorCode,
+            $exception->getMessage(),
+            $exception->getStatusCode(),
+            ['errors' => $exception->getErrors()],
+        );
+    }
+}

--- a/src/EventListener/ExceptionMapper/ExceptionMapperInterface.php
+++ b/src/EventListener/ExceptionMapper/ExceptionMapperInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener\ExceptionMapper;
+
+/**
+ * Interface for exception mappers that convert exceptions to error responses.
+ *
+ * Mappers are checked in priority order (highest first). The first mapper
+ * that can handle an exception will be used to create the mapping.
+ *
+ * Priority ranges:
+ * - 100+: Domain exceptions (most specific)
+ * - 50-99: Symfony validation/security exceptions
+ * - 1-49: HTTP exceptions
+ * - 0: Fallback/server error
+ */
+interface ExceptionMapperInterface
+{
+    /**
+     * Returns the priority of this mapper.
+     *
+     * Higher priority mappers are checked first, allowing more specific
+     * mappers to take precedence over generic ones.
+     */
+    public static function getPriority(): int;
+
+    /**
+     * Determines if this mapper can handle the given exception.
+     */
+    public function canHandle(\Throwable $exception): bool;
+
+    /**
+     * Maps the exception to an ExceptionMapping value object.
+     *
+     * Only called when canHandle() returns true.
+     */
+    public function map(\Throwable $exception): ExceptionMapping;
+}

--- a/src/EventListener/ExceptionMapper/ExceptionMapperRegistry.php
+++ b/src/EventListener/ExceptionMapper/ExceptionMapperRegistry.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener\ExceptionMapper;
+
+use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Registry that aggregates exception mappers and finds the appropriate one for an exception.
+ *
+ * Mappers are sorted by priority (highest first) and the first mapper that can handle
+ * the exception is used to create the mapping.
+ */
+final class ExceptionMapperRegistry
+{
+    /** @var ExceptionMapperInterface[] */
+    private array $mappers;
+
+    /**
+     * @param iterable<ExceptionMapperInterface> $mappers
+     */
+    public function __construct(
+        #[TaggedIterator('app.exception_mapper', defaultPriorityMethod: 'getPriority')]
+        iterable $mappers,
+    ) {
+        $this->mappers = iterator_to_array($mappers);
+    }
+
+    /**
+     * Finds the appropriate mapper for the exception and returns the mapping.
+     *
+     * Falls back to a generic server error if no mapper handles the exception.
+     */
+    public function map(\Throwable $exception): ExceptionMapping
+    {
+        foreach ($this->mappers as $mapper) {
+            if ($mapper->canHandle($exception)) {
+                return $mapper->map($exception);
+            }
+        }
+
+        // Fallback if no mapper handles the exception (shouldn't happen with ServerErrorMapper)
+        return new ExceptionMapping(
+            'SERVER_ERROR',
+            'An internal server error occurred',
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+        );
+    }
+}

--- a/src/EventListener/ExceptionMapper/ExceptionMapping.php
+++ b/src/EventListener/ExceptionMapper/ExceptionMapping.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener\ExceptionMapper;
+
+/**
+ * Immutable value object representing an exception mapping result.
+ */
+final readonly class ExceptionMapping
+{
+    /**
+     * @param string $errorCode Machine-readable error code (e.g., 'VALIDATION_ERROR')
+     * @param string $message Human-readable error message
+     * @param int $statusCode HTTP status code
+     * @param array<string, mixed> $details Additional error details
+     */
+    public function __construct(
+        public string $errorCode,
+        public string $message,
+        public int $statusCode,
+        public array $details = [],
+    ) {
+    }
+}

--- a/src/EventListener/ExceptionMapper/Fallback/ServerErrorMapper.php
+++ b/src/EventListener/ExceptionMapper/Fallback/ServerErrorMapper.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener\ExceptionMapper\Fallback;
+
+use App\EventListener\ExceptionMapper\ExceptionMapperInterface;
+use App\EventListener\ExceptionMapper\ExceptionMapping;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Fallback mapper for any unhandled exceptions.
+ *
+ * Always returns a 500 Internal Server Error. In development mode,
+ * includes additional debug information.
+ */
+#[AutoconfigureTag('app.exception_mapper')]
+final class ServerErrorMapper implements ExceptionMapperInterface
+{
+    public function __construct(
+        private readonly string $environment,
+    ) {
+    }
+
+    public static function getPriority(): int
+    {
+        return 0;
+    }
+
+    public function canHandle(\Throwable $exception): bool
+    {
+        return true;
+    }
+
+    public function map(\Throwable $exception): ExceptionMapping
+    {
+        $message = $this->environment === 'dev'
+            ? $exception->getMessage()
+            : 'An internal server error occurred';
+
+        $details = [];
+
+        if ($this->environment === 'dev') {
+            $details = [
+                'exception' => get_class($exception),
+                'file' => $exception->getFile(),
+                'line' => $exception->getLine(),
+            ];
+        }
+
+        return new ExceptionMapping(
+            'SERVER_ERROR',
+            $message,
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            $details,
+        );
+    }
+}

--- a/src/EventListener/ExceptionMapper/Symfony/AccessDeniedExceptionMapper.php
+++ b/src/EventListener/ExceptionMapper/Symfony/AccessDeniedExceptionMapper.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener\ExceptionMapper\Symfony;
+
+use App\EventListener\ExceptionMapper\ExceptionMapperInterface;
+use App\EventListener\ExceptionMapper\ExceptionMapping;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * Maps Symfony Security AccessDeniedException to error response.
+ *
+ * Note: This handles the Security component exception, which typically
+ * means the user is not authenticated (401), not that they lack permissions (403).
+ */
+#[AutoconfigureTag('app.exception_mapper')]
+final class AccessDeniedExceptionMapper implements ExceptionMapperInterface
+{
+    public static function getPriority(): int
+    {
+        return 75;
+    }
+
+    public function canHandle(\Throwable $exception): bool
+    {
+        return $exception instanceof AccessDeniedException;
+    }
+
+    public function map(\Throwable $exception): ExceptionMapping
+    {
+        return new ExceptionMapping(
+            'UNAUTHORIZED',
+            'Authentication required',
+            Response::HTTP_UNAUTHORIZED,
+        );
+    }
+}

--- a/src/EventListener/ExceptionMapper/Symfony/AuthenticationExceptionMapper.php
+++ b/src/EventListener/ExceptionMapper/Symfony/AuthenticationExceptionMapper.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener\ExceptionMapper\Symfony;
+
+use App\EventListener\ExceptionMapper\ExceptionMapperInterface;
+use App\EventListener\ExceptionMapper\ExceptionMapping;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+/**
+ * Maps Symfony AuthenticationException to error response.
+ */
+#[AutoconfigureTag('app.exception_mapper')]
+final class AuthenticationExceptionMapper implements ExceptionMapperInterface
+{
+    public static function getPriority(): int
+    {
+        return 75;
+    }
+
+    public function canHandle(\Throwable $exception): bool
+    {
+        return $exception instanceof AuthenticationException;
+    }
+
+    public function map(\Throwable $exception): ExceptionMapping
+    {
+        return new ExceptionMapping(
+            'UNAUTHORIZED',
+            'Authentication required',
+            Response::HTTP_UNAUTHORIZED,
+        );
+    }
+}

--- a/src/EventListener/ExceptionMapper/Symfony/HttpExceptionMapper.php
+++ b/src/EventListener/ExceptionMapper/Symfony/HttpExceptionMapper.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener\ExceptionMapper\Symfony;
+
+use App\EventListener\ExceptionMapper\ExceptionMapperInterface;
+use App\EventListener\ExceptionMapper\ExceptionMapping;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * Maps Symfony HttpExceptionInterface exceptions to error responses.
+ *
+ * Handles all HTTP exceptions with appropriate error codes based on
+ * the specific exception type or HTTP status code.
+ */
+#[AutoconfigureTag('app.exception_mapper')]
+final class HttpExceptionMapper implements ExceptionMapperInterface
+{
+    public static function getPriority(): int
+    {
+        return 10;
+    }
+
+    public function canHandle(\Throwable $exception): bool
+    {
+        return $exception instanceof HttpExceptionInterface;
+    }
+
+    public function map(\Throwable $exception): ExceptionMapping
+    {
+        assert($exception instanceof HttpExceptionInterface);
+
+        $statusCode = $exception->getStatusCode();
+        $message = $exception->getMessage();
+
+        if (empty($message)) {
+            $message = Response::$statusTexts[$statusCode] ?? 'An error occurred';
+        }
+
+        $errorCode = $this->resolveErrorCode($exception, $statusCode);
+
+        return new ExceptionMapping($errorCode, $message, $statusCode);
+    }
+
+    private function resolveErrorCode(HttpExceptionInterface $exception, int $statusCode): string
+    {
+        return match (true) {
+            $exception instanceof NotFoundHttpException => 'NOT_FOUND',
+            $exception instanceof UnauthorizedHttpException => 'UNAUTHORIZED',
+            $exception instanceof AccessDeniedHttpException => 'FORBIDDEN',
+            $exception instanceof TooManyRequestsHttpException => 'RATE_LIMIT_EXCEEDED',
+            $exception instanceof BadRequestHttpException => 'BAD_REQUEST',
+            $exception instanceof UnprocessableEntityHttpException => 'VALIDATION_ERROR',
+            $exception instanceof ConflictHttpException => 'CONFLICT',
+            default => $this->getErrorCodeFromStatusCode($statusCode),
+        };
+    }
+
+    private function getErrorCodeFromStatusCode(int $statusCode): string
+    {
+        return match ($statusCode) {
+            400 => 'BAD_REQUEST',
+            401 => 'UNAUTHORIZED',
+            403 => 'FORBIDDEN',
+            404 => 'NOT_FOUND',
+            405 => 'METHOD_NOT_ALLOWED',
+            409 => 'CONFLICT',
+            422 => 'VALIDATION_ERROR',
+            429 => 'RATE_LIMIT_EXCEEDED',
+            500 => 'SERVER_ERROR',
+            501 => 'NOT_IMPLEMENTED',
+            503 => 'SERVICE_UNAVAILABLE',
+            default => 'ERROR',
+        };
+    }
+}

--- a/src/EventListener/ExceptionMapper/Symfony/ValidationFailedExceptionMapper.php
+++ b/src/EventListener/ExceptionMapper/Symfony/ValidationFailedExceptionMapper.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener\ExceptionMapper\Symfony;
+
+use App\EventListener\ExceptionMapper\ExceptionMapperInterface;
+use App\EventListener\ExceptionMapper\ExceptionMapping;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Exception\ValidationFailedException;
+
+/**
+ * Maps Symfony ValidationFailedException to error response.
+ */
+#[AutoconfigureTag('app.exception_mapper')]
+final class ValidationFailedExceptionMapper implements ExceptionMapperInterface
+{
+    public static function getPriority(): int
+    {
+        return 75;
+    }
+
+    public function canHandle(\Throwable $exception): bool
+    {
+        return $exception instanceof ValidationFailedException;
+    }
+
+    public function map(\Throwable $exception): ExceptionMapping
+    {
+        assert($exception instanceof ValidationFailedException);
+
+        $violations = $exception->getViolations();
+        $errors = [];
+
+        foreach ($violations as $violation) {
+            $propertyPath = $violation->getPropertyPath();
+            $errors[$propertyPath][] = $violation->getMessage();
+        }
+
+        return new ExceptionMapping(
+            'VALIDATION_ERROR',
+            'Validation failed',
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+            ['errors' => $errors],
+        );
+    }
+}

--- a/tests/Unit/EventListener/ExceptionMapper/Domain/EntityNotFoundExceptionMapperTest.php
+++ b/tests/Unit/EventListener/ExceptionMapper/Domain/EntityNotFoundExceptionMapperTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\EventListener\ExceptionMapper\Domain;
+
+use App\EventListener\ExceptionMapper\Domain\EntityNotFoundExceptionMapper;
+use App\EventListener\ExceptionMapper\ExceptionMapping;
+use App\Exception\EntityNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+class EntityNotFoundExceptionMapperTest extends TestCase
+{
+    private EntityNotFoundExceptionMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new EntityNotFoundExceptionMapper();
+    }
+
+    public function testCanHandleReturnsTrueForEntityNotFoundException(): void
+    {
+        $exception = new EntityNotFoundException('Task', 'task-123');
+        $this->assertTrue($this->mapper->canHandle($exception));
+    }
+
+    public function testCanHandleReturnsFalseForOtherExceptions(): void
+    {
+        $this->assertFalse($this->mapper->canHandle(new \Exception()));
+        $this->assertFalse($this->mapper->canHandle(new \RuntimeException()));
+    }
+
+    public function testMapReturnsCorrectMapping(): void
+    {
+        $exception = new EntityNotFoundException('Task', 'task-123');
+
+        $mapping = $this->mapper->map($exception);
+
+        $this->assertInstanceOf(ExceptionMapping::class, $mapping);
+        $this->assertSame('RESOURCE_NOT_FOUND', $mapping->errorCode);
+        $this->assertSame(404, $mapping->statusCode);
+        $this->assertSame('Task', $mapping->details['entityType']);
+        $this->assertSame('task-123', $mapping->details['entityId']);
+    }
+
+    public function testPriorityIs100(): void
+    {
+        $this->assertSame(100, EntityNotFoundExceptionMapper::getPriority());
+    }
+}

--- a/tests/Unit/EventListener/ExceptionMapper/Domain/InvalidStatusExceptionMapperTest.php
+++ b/tests/Unit/EventListener/ExceptionMapper/Domain/InvalidStatusExceptionMapperTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\EventListener\ExceptionMapper\Domain;
+
+use App\EventListener\ExceptionMapper\Domain\InvalidStatusExceptionMapper;
+use App\EventListener\ExceptionMapper\ExceptionMapping;
+use App\Exception\InvalidStatusException;
+use PHPUnit\Framework\TestCase;
+
+class InvalidStatusExceptionMapperTest extends TestCase
+{
+    private InvalidStatusExceptionMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new InvalidStatusExceptionMapper();
+    }
+
+    public function testCanHandleReturnsTrueForInvalidStatusException(): void
+    {
+        $exception = new InvalidStatusException('invalid', ['pending', 'completed']);
+        $this->assertTrue($this->mapper->canHandle($exception));
+    }
+
+    public function testCanHandleReturnsFalseForOtherExceptions(): void
+    {
+        $this->assertFalse($this->mapper->canHandle(new \Exception()));
+        $this->assertFalse($this->mapper->canHandle(new \RuntimeException()));
+    }
+
+    public function testMapReturnsCorrectMapping(): void
+    {
+        $exception = new InvalidStatusException('unknown', ['pending', 'completed']);
+
+        $mapping = $this->mapper->map($exception);
+
+        $this->assertInstanceOf(ExceptionMapping::class, $mapping);
+        $this->assertSame('INVALID_STATUS', $mapping->errorCode);
+        $this->assertSame(400, $mapping->statusCode);
+        $this->assertSame('unknown', $mapping->details['invalidStatus']);
+        $this->assertSame(['pending', 'completed'], $mapping->details['validStatuses']);
+    }
+
+    public function testPriorityIs100(): void
+    {
+        $this->assertSame(100, InvalidStatusExceptionMapper::getPriority());
+    }
+}

--- a/tests/Unit/EventListener/ExceptionMapper/Domain/ValidationExceptionMapperTest.php
+++ b/tests/Unit/EventListener/ExceptionMapper/Domain/ValidationExceptionMapperTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\EventListener\ExceptionMapper\Domain;
+
+use App\EventListener\ExceptionMapper\Domain\ValidationExceptionMapper;
+use App\EventListener\ExceptionMapper\ExceptionMapping;
+use App\Exception\ValidationException;
+use PHPUnit\Framework\TestCase;
+
+class ValidationExceptionMapperTest extends TestCase
+{
+    private ValidationExceptionMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new ValidationExceptionMapper();
+    }
+
+    public function testCanHandleReturnsTrueForValidationException(): void
+    {
+        $exception = new ValidationException(['field' => 'required']);
+        $this->assertTrue($this->mapper->canHandle($exception));
+    }
+
+    public function testCanHandleReturnsFalseForOtherExceptions(): void
+    {
+        $this->assertFalse($this->mapper->canHandle(new \Exception()));
+        $this->assertFalse($this->mapper->canHandle(new \RuntimeException()));
+    }
+
+    public function testMapReturnsCorrectMapping(): void
+    {
+        $errors = ['email' => 'Invalid email', 'password' => 'Too short'];
+        $exception = new ValidationException($errors);
+
+        $mapping = $this->mapper->map($exception);
+
+        $this->assertInstanceOf(ExceptionMapping::class, $mapping);
+        $this->assertSame('VALIDATION_ERROR', $mapping->errorCode);
+        $this->assertSame('Validation failed', $mapping->message);
+        $this->assertSame(422, $mapping->statusCode);
+        $this->assertSame(['errors' => $errors], $mapping->details);
+    }
+
+    public function testPriorityIs100(): void
+    {
+        $this->assertSame(100, ValidationExceptionMapper::getPriority());
+    }
+}

--- a/tests/Unit/EventListener/ExceptionMapper/ExceptionMapperRegistryTest.php
+++ b/tests/Unit/EventListener/ExceptionMapper/ExceptionMapperRegistryTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\EventListener\ExceptionMapper;
+
+use App\EventListener\ExceptionMapper\ExceptionMapperInterface;
+use App\EventListener\ExceptionMapper\ExceptionMapperRegistry;
+use App\EventListener\ExceptionMapper\ExceptionMapping;
+use PHPUnit\Framework\TestCase;
+
+class ExceptionMapperRegistryTest extends TestCase
+{
+    public function testMapReturnsFirstMatchingMapperResult(): void
+    {
+        $exception = new \RuntimeException('Test error');
+
+        $mapper1 = $this->createMockMapper(false, null);
+        $mapper2 = $this->createMockMapper(true, new ExceptionMapping('ERROR_2', 'Error 2', 400));
+        $mapper3 = $this->createMockMapper(true, new ExceptionMapping('ERROR_3', 'Error 3', 500));
+
+        $registry = new ExceptionMapperRegistry([$mapper1, $mapper2, $mapper3]);
+        $result = $registry->map($exception);
+
+        $this->assertSame('ERROR_2', $result->errorCode);
+        $this->assertSame('Error 2', $result->message);
+        $this->assertSame(400, $result->statusCode);
+    }
+
+    public function testMapReturnsFallbackWhenNoMapperHandles(): void
+    {
+        $exception = new \RuntimeException('Test error');
+
+        $mapper = $this->createMockMapper(false, null);
+
+        $registry = new ExceptionMapperRegistry([$mapper]);
+        $result = $registry->map($exception);
+
+        $this->assertSame('SERVER_ERROR', $result->errorCode);
+        $this->assertSame(500, $result->statusCode);
+    }
+
+    public function testMappersAreCalledInOrder(): void
+    {
+        $exception = new \RuntimeException('Test error');
+        $callOrder = [];
+
+        $mapper1 = $this->createMock(ExceptionMapperInterface::class);
+        $mapper1->method('canHandle')->willReturnCallback(function () use (&$callOrder) {
+            $callOrder[] = 1;
+            return false;
+        });
+
+        $mapper2 = $this->createMock(ExceptionMapperInterface::class);
+        $mapper2->method('canHandle')->willReturnCallback(function () use (&$callOrder) {
+            $callOrder[] = 2;
+            return true;
+        });
+        $mapper2->method('map')->willReturn(new ExceptionMapping('ERROR', 'Error', 500));
+
+        $registry = new ExceptionMapperRegistry([$mapper1, $mapper2]);
+        $registry->map($exception);
+
+        $this->assertSame([1, 2], $callOrder);
+    }
+
+    private function createMockMapper(bool $canHandle, ?ExceptionMapping $mapping): ExceptionMapperInterface
+    {
+        $mapper = $this->createMock(ExceptionMapperInterface::class);
+        $mapper->method('canHandle')->willReturn($canHandle);
+
+        if ($mapping !== null) {
+            $mapper->method('map')->willReturn($mapping);
+        }
+
+        return $mapper;
+    }
+}

--- a/tests/Unit/EventListener/ExceptionMapper/ExceptionMappingTest.php
+++ b/tests/Unit/EventListener/ExceptionMapper/ExceptionMappingTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\EventListener\ExceptionMapper;
+
+use App\EventListener\ExceptionMapper\ExceptionMapping;
+use PHPUnit\Framework\TestCase;
+
+class ExceptionMappingTest extends TestCase
+{
+    public function testConstructorSetsAllProperties(): void
+    {
+        $mapping = new ExceptionMapping(
+            'VALIDATION_ERROR',
+            'Validation failed',
+            422,
+            ['errors' => ['field' => 'required']],
+        );
+
+        $this->assertSame('VALIDATION_ERROR', $mapping->errorCode);
+        $this->assertSame('Validation failed', $mapping->message);
+        $this->assertSame(422, $mapping->statusCode);
+        $this->assertSame(['errors' => ['field' => 'required']], $mapping->details);
+    }
+
+    public function testDefaultDetailsIsEmptyArray(): void
+    {
+        $mapping = new ExceptionMapping('ERROR', 'An error', 500);
+
+        $this->assertSame([], $mapping->details);
+    }
+
+    public function testIsImmutable(): void
+    {
+        $mapping = new ExceptionMapping('ERROR', 'An error', 500);
+
+        // Verify readonly properties - these should all be readonly
+        $reflection = new \ReflectionClass($mapping);
+        $this->assertTrue($reflection->isReadOnly());
+    }
+}

--- a/tests/Unit/EventListener/ExceptionMapper/Fallback/ServerErrorMapperTest.php
+++ b/tests/Unit/EventListener/ExceptionMapper/Fallback/ServerErrorMapperTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\EventListener\ExceptionMapper\Fallback;
+
+use App\EventListener\ExceptionMapper\ExceptionMapping;
+use App\EventListener\ExceptionMapper\Fallback\ServerErrorMapper;
+use PHPUnit\Framework\TestCase;
+
+class ServerErrorMapperTest extends TestCase
+{
+    public function testCanHandleAlwaysReturnsTrue(): void
+    {
+        $mapper = new ServerErrorMapper('prod');
+
+        $this->assertTrue($mapper->canHandle(new \Exception()));
+        $this->assertTrue($mapper->canHandle(new \RuntimeException()));
+        $this->assertTrue($mapper->canHandle(new \InvalidArgumentException()));
+    }
+
+    public function testMapReturnsServerErrorInProduction(): void
+    {
+        $mapper = new ServerErrorMapper('prod');
+        $exception = new \RuntimeException('Sensitive error message');
+
+        $mapping = $mapper->map($exception);
+
+        $this->assertInstanceOf(ExceptionMapping::class, $mapping);
+        $this->assertSame('SERVER_ERROR', $mapping->errorCode);
+        $this->assertSame('An internal server error occurred', $mapping->message);
+        $this->assertSame(500, $mapping->statusCode);
+        $this->assertSame([], $mapping->details);
+    }
+
+    public function testMapReturnsDebugInfoInDevelopment(): void
+    {
+        $mapper = new ServerErrorMapper('dev');
+        $exception = new \RuntimeException('Detailed error message');
+
+        $mapping = $mapper->map($exception);
+
+        $this->assertSame('SERVER_ERROR', $mapping->errorCode);
+        $this->assertSame('Detailed error message', $mapping->message);
+        $this->assertSame(500, $mapping->statusCode);
+        $this->assertSame(\RuntimeException::class, $mapping->details['exception']);
+        $this->assertArrayHasKey('file', $mapping->details);
+        $this->assertArrayHasKey('line', $mapping->details);
+    }
+
+    public function testPriorityIsZero(): void
+    {
+        $this->assertSame(0, ServerErrorMapper::getPriority());
+    }
+}

--- a/tests/Unit/EventListener/ExceptionMapper/Symfony/HttpExceptionMapperTest.php
+++ b/tests/Unit/EventListener/ExceptionMapper/Symfony/HttpExceptionMapperTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\EventListener\ExceptionMapper\Symfony;
+
+use App\EventListener\ExceptionMapper\ExceptionMapping;
+use App\EventListener\ExceptionMapper\Symfony\HttpExceptionMapper;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+class HttpExceptionMapperTest extends TestCase
+{
+    private HttpExceptionMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new HttpExceptionMapper();
+    }
+
+    public function testCanHandleReturnsTrueForHttpExceptions(): void
+    {
+        $this->assertTrue($this->mapper->canHandle(new NotFoundHttpException()));
+        $this->assertTrue($this->mapper->canHandle(new BadRequestHttpException()));
+        $this->assertTrue($this->mapper->canHandle(new HttpException(500)));
+    }
+
+    public function testCanHandleReturnsFalseForOtherExceptions(): void
+    {
+        $this->assertFalse($this->mapper->canHandle(new \Exception()));
+        $this->assertFalse($this->mapper->canHandle(new \RuntimeException()));
+    }
+
+    /**
+     * @dataProvider httpExceptionProvider
+     */
+    public function testMapReturnsCorrectErrorCodes(
+        \Throwable $exception,
+        string $expectedErrorCode,
+        int $expectedStatusCode,
+    ): void {
+        $mapping = $this->mapper->map($exception);
+
+        $this->assertInstanceOf(ExceptionMapping::class, $mapping);
+        $this->assertSame($expectedErrorCode, $mapping->errorCode);
+        $this->assertSame($expectedStatusCode, $mapping->statusCode);
+    }
+
+    /**
+     * @return array<string, array{0: \Throwable, 1: string, 2: int}>
+     */
+    public static function httpExceptionProvider(): array
+    {
+        return [
+            'NotFoundHttpException' => [new NotFoundHttpException(), 'NOT_FOUND', 404],
+            'UnauthorizedHttpException' => [new UnauthorizedHttpException('Bearer'), 'UNAUTHORIZED', 401],
+            'AccessDeniedHttpException' => [new AccessDeniedHttpException(), 'FORBIDDEN', 403],
+            'TooManyRequestsHttpException' => [new TooManyRequestsHttpException(), 'RATE_LIMIT_EXCEEDED', 429],
+            'BadRequestHttpException' => [new BadRequestHttpException(), 'BAD_REQUEST', 400],
+            'UnprocessableEntityHttpException' => [new UnprocessableEntityHttpException(), 'VALIDATION_ERROR', 422],
+            'ConflictHttpException' => [new ConflictHttpException(), 'CONFLICT', 409],
+            'GenericHttpException400' => [new HttpException(400), 'BAD_REQUEST', 400],
+            'GenericHttpException503' => [new HttpException(503), 'SERVICE_UNAVAILABLE', 503],
+        ];
+    }
+
+    public function testMapUsesExceptionMessageWhenProvided(): void
+    {
+        $exception = new NotFoundHttpException('Resource not found');
+        $mapping = $this->mapper->map($exception);
+
+        $this->assertSame('Resource not found', $mapping->message);
+    }
+
+    public function testMapUsesDefaultMessageWhenEmpty(): void
+    {
+        $exception = new NotFoundHttpException();
+        $mapping = $this->mapper->map($exception);
+
+        $this->assertSame('Not Found', $mapping->message);
+    }
+
+    public function testPriorityIs10(): void
+    {
+        $this->assertSame(10, HttpExceptionMapper::getPriority());
+    }
+}


### PR DESCRIPTION
## Summary

Refactored the monolithic `ApiExceptionListener` (326 lines with 18 `instanceof` checks) into a clean, maintainable architecture using the Strategy pattern. Exception handling is now delegated to specialized mapper classes, each responsible for a single exception type.

## Key Changes

- **Extracted `ExceptionMapperInterface`**: Contract defining `canHandle()`, `map()`, and `getPriority()` methods for all exception mappers
- **Created `ExceptionMapping` value object**: Immutable result object containing `errorCode`, `message`, `statusCode`, and `details`
- **Implemented `ExceptionMapperRegistry`**: Aggregates mappers via Symfony's tagged iterator and dispatches to the first mapper that can handle an exception
- **Created 12 specialized mapper classes**:
  - **Domain mappers** (priority 100): `ValidationExceptionMapper`, `InvalidStatusExceptionMapper`, `InvalidPriorityExceptionMapper`, `InvalidRecurrenceExceptionMapper`, `EntityNotFoundExceptionMapper`, `UnauthorizedExceptionMapper`, `ForbiddenExceptionMapper`
  - **Symfony mappers** (priority 75/10): `ValidationFailedExceptionMapper`, `AuthenticationExceptionMapper`, `AccessDeniedExceptionMapper`, `HttpExceptionMapper`
  - **Fallback mapper** (priority 0): `ServerErrorMapper` for unhandled exceptions
- **Simplified `ApiExceptionListener`**: Reduced from 326 to 69 lines (79% reduction), now acts as a simple orchestrator
- **Updated service configuration**: Registered mappers via `#[AutoconfigureTag('app.exception_mapper')]` attribute with priority-based sorting

## Implementation Details

- Mappers are auto-discovered and sorted by priority (highest first), ensuring specific domain exceptions are matched before generic HTTP exceptions
- Priority system: Domain (100) → Symfony validation/security (75) → HTTP (10) → Fallback (0)
- `ServerErrorMapper` receives `$environment` parameter to conditionally include debug info in development mode
- All mappers are trivial to unit test in isolation

## Tests Added

36 new unit tests covering:
- `ExceptionMappingTest`: Value object immutability and properties
- `ExceptionMapperRegistryTest`: Mapper dispatch logic and fallback behavior
- Domain mapper tests: `ValidationExceptionMapperTest`, `InvalidStatusExceptionMapperTest`, `EntityNotFoundExceptionMapperTest`
- Symfony mapper tests: `HttpExceptionMapperTest`
- Fallback mapper tests: `ServerErrorMapperTest`

All tests passing.

## Benefits

✅ **SRP Compliance**: Each mapper handles exactly one exception type  
✅ **Open/Closed Principle**: New exceptions require only a new mapper class  
✅ **Testability**: Each mapper is trivial to unit test  
✅ **Discoverability**: Symfony's autoconfigure automatically registers mappers  
✅ **Maintainability**: 79% reduction in main listener complexity