### PR TITLE
Hash email addresses in logs to protect PII

### DIFF
--- a/docs/PHASE-1-REVIEW-PLAN.md
+++ b/docs/PHASE-1-REVIEW-PLAN.md
@@ -454,10 +454,11 @@ Reduce to 24-48 hours for sensitive applications, or 30 days maximum.
 
 ---
 
-### 3.4 Email Addresses Logged in Plain Text
+### 3.4 Email Addresses Logged in Plain Text ✅ FIXED
 
 **Category:** Data Safety
-**Files:** `src/Service/ApiLogger.php`, `src/Controller/Api/AuthController.php`
+**Files:** `src/Service/ApiLogger.php`, `src/Controller/Api/AuthController.php`, `src/Security/ApiTokenAuthenticator.php`
+**Status:** RESOLVED (2026-01-24)
 
 #### Issue
 Email addresses logged on authentication events, exposing PII if logs are compromised.
@@ -467,6 +468,30 @@ Hash or truncate emails in log context:
 ```php
 'email_hash' => substr(hash('sha256', $email), 0, 16)
 ```
+
+#### Resolution
+All email logging has been updated to use hashed email addresses instead of plain text:
+
+1. **Added `ApiLogger::hashEmail()` static method** (`src/Service/ApiLogger.php:178-190`):
+   - Returns a 16-character truncated SHA-256 hash
+   - Allows correlation of log entries without exposing full email
+   - Consistent output for same input enables tracking user activity
+
+2. **Updated AuthController.php** - 9 logging calls updated:
+   - Registration validation failed
+   - Registration attempt for existing email
+   - User registered successfully
+   - Registration exception caught
+   - Login rate limit exceeded
+   - Login attempt for non-existent user
+   - Login attempt with invalid password
+   - User logged in successfully
+   - User logged out (token revoked)
+
+3. **Updated ApiTokenAuthenticator.php** - 1 logging call updated:
+   - User authenticated successfully
+
+All log entries now use `'email_hash' => ApiLogger::hashEmail($email)` instead of exposing plain text email addresses.
 
 ---
 

--- a/src/Controller/Api/AuthController.php
+++ b/src/Controller/Api/AuthController.php
@@ -56,7 +56,7 @@ final class AuthController extends AbstractController
             }
 
             $this->apiLogger->logWarning('Registration validation failed', [
-                'email' => $registerRequest->email,
+                'email_hash' => ApiLogger::hashEmail($registerRequest->email),
                 'errors' => $validationErrors,
             ]);
 
@@ -72,7 +72,7 @@ final class AuthController extends AbstractController
         $existingUser = $this->userService->findByEmail($registerRequest->email);
         if ($existingUser !== null) {
             $this->apiLogger->logWarning('Registration attempt for existing email', [
-                'email' => $registerRequest->email,
+                'email_hash' => ApiLogger::hashEmail($registerRequest->email),
             ]);
 
             return $this->responseFormatter->error(
@@ -91,7 +91,7 @@ final class AuthController extends AbstractController
 
             $this->apiLogger->logInfo('User registered successfully', [
                 'user_id' => $user->getId(),
-                'email' => $user->getEmail(),
+                'email_hash' => ApiLogger::hashEmail($user->getEmail()),
             ]);
 
             $userResponse = UserResponse::fromUser($user);
@@ -103,7 +103,7 @@ final class AuthController extends AbstractController
             ]);
         } catch (\Exception $e) {
             $this->apiLogger->logError($e, [
-                'email' => $registerRequest->email,
+                'email_hash' => ApiLogger::hashEmail($registerRequest->email),
             ]);
 
             return $this->responseFormatter->error(
@@ -152,7 +152,7 @@ final class AuthController extends AbstractController
             $retryAfter = $limit->getRetryAfter();
 
             $this->apiLogger->logWarning('Login rate limit exceeded', [
-                'email' => $loginRequest->email,
+                'email_hash' => ApiLogger::hashEmail($loginRequest->email),
                 'ip' => $request->getClientIp(),
                 'retry_after' => $retryAfter->getTimestamp(),
             ]);
@@ -174,7 +174,7 @@ final class AuthController extends AbstractController
         $user = $this->userService->findByEmail($loginRequest->email);
         if ($user === null) {
             $this->apiLogger->logWarning('Login attempt for non-existent user', [
-                'email' => $loginRequest->email,
+                'email_hash' => ApiLogger::hashEmail($loginRequest->email),
                 'ip' => $request->getClientIp(),
             ]);
 
@@ -188,7 +188,7 @@ final class AuthController extends AbstractController
         // Validate password
         if (!$this->userService->validatePassword($user, $loginRequest->password)) {
             $this->apiLogger->logWarning('Login attempt with invalid password', [
-                'email' => $loginRequest->email,
+                'email_hash' => ApiLogger::hashEmail($loginRequest->email),
                 'ip' => $request->getClientIp(),
             ]);
 
@@ -204,7 +204,7 @@ final class AuthController extends AbstractController
 
         $this->apiLogger->logInfo('User logged in successfully', [
             'user_id' => $user->getId(),
-            'email' => $user->getEmail(),
+            'email_hash' => ApiLogger::hashEmail($user->getEmail()),
         ]);
 
         $tokenResponse = new TokenResponse($apiToken);
@@ -235,7 +235,7 @@ final class AuthController extends AbstractController
 
         $this->apiLogger->logInfo('User logged out (token revoked)', [
             'user_id' => $user->getId(),
-            'email' => $user->getEmail(),
+            'email_hash' => ApiLogger::hashEmail($user->getEmail()),
         ]);
 
         return $this->responseFormatter->noContent();

--- a/src/Security/ApiTokenAuthenticator.php
+++ b/src/Security/ApiTokenAuthenticator.php
@@ -95,7 +95,7 @@ final class ApiTokenAuthenticator extends AbstractAuthenticator
 
                 $this->apiLogger->logInfo('User authenticated successfully', [
                     'user_id' => $user->getId(),
-                    'email' => $user->getEmail(),
+                    'email_hash' => ApiLogger::hashEmail($user->getEmail()),
                 ]);
 
                 return $user;

--- a/src/Service/ApiLogger.php
+++ b/src/Service/ApiLogger.php
@@ -173,4 +173,18 @@ final class ApiLogger
             default => 'info',
         };
     }
+
+    /**
+     * Hashes an email address for safe logging.
+     *
+     * Returns a truncated SHA-256 hash that allows correlation
+     * of log entries without exposing the full email address.
+     *
+     * @param string $email The email address to hash
+     * @return string 16-character truncated hash
+     */
+    public static function hashEmail(string $email): string
+    {
+        return substr(hash('sha256', $email), 0, 16);
+    }
 }


### PR DESCRIPTION
## Summary
Resolves security issue 3.4 by replacing plain text email logging with hashed email addresses across authentication and API logging. This prevents exposure of personally identifiable information (PII) if logs are compromised while maintaining the ability to correlate log entries for the same user.

## Changes Made

- **Added `ApiLogger::hashEmail()` static method** - New utility method that returns a 16-character truncated SHA-256 hash of email addresses, enabling safe logging with user activity correlation
  
- **Updated AuthController.php** - Replaced 9 plain text email log entries with hashed versions:
  - Registration validation failures
  - Duplicate email registration attempts
  - Successful user registration
  - Registration exceptions
  - Login rate limit exceeded
  - Non-existent user login attempts
  - Invalid password login attempts
  - Successful user login
  - User logout (token revocation)

- **Updated ApiTokenAuthenticator.php** - Replaced 1 plain text email log entry with hashed version during user authentication

- **Updated documentation** - Marked issue 3.4 as FIXED with detailed resolution notes in PHASE-1-REVIEW-PLAN.md

## Implementation Details

The `hashEmail()` method uses SHA-256 hashing with a 16-character truncation, providing:
- **Security**: Email addresses are not exposed in logs
- **Correlation**: Consistent hash output for the same email enables tracking user activity across log entries
- **Simplicity**: Static method allows easy integration throughout the codebase without instantiation

All log entries now use `'email_hash' => ApiLogger::hashEmail($email)` instead of `'email' => $email`.